### PR TITLE
Fix issue #12

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -342,9 +342,11 @@ class Database {
                       }
                     : null
             };
-            const resource = {
-                data: doc ? doc.fields : null
-            };
+            const resource = doc 
+                    ? {
+                          data: doc.fields
+                      }
+                    : null;
 
             return {
                 expectation,


### PR DESCRIPTION
`resource` should be null when there is no existing document, not `resource.data`.