### PR TITLE
add babel-plugin-transform-runtime. fixes #1, #18

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
       "stage-0"
   ],
   "plugins": [
-    "transform-flow-strip-types"
+    "transform-flow-strip-types",
+    "babel-plugin-transform-runtime"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "babel-eslint": "^8.0.2",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "eslint": "^4.12.0",


### PR DESCRIPTION
[babel-plugin-transform-runtime](http://babeljs.io/docs/en/babel-plugin-transform-runtime/) is the preferred way to export polyfills for libraries to avoid poluting the global scope.

The fix proposed in issue #1 isn't a good option in my opinion because it forces users, who might have zero idea of what transpiling or babel are, to add more dependencies to make this library "just work". I think the end result of a transpiling should always be immediately usable with a default setup.

If adding this transform is a problem for the author or some users, a workaround I can propose is to publish the module with both `lib/` and `src/` folders, which will allow users to choose un-transpiled version with very little module folder size overhead and no performance penalty.

